### PR TITLE
Update rake dependency.

### DIFF
--- a/typed_store_accessor.gemspec
+++ b/typed_store_accessor.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "byebug"
   spec.add_dependency "activesupport"


### PR DESCRIPTION
Address the alert for CVE-2020-8130.